### PR TITLE
Nav bar with text logo and menu

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,6 +41,7 @@
           <ul class="flex space-x-8">
             <li><%= link_to "Home", root_path, class: "text-gray-600 hover:text-gray-90 px-4 py-1" %></li>
             <li><%= link_to "Progress", progress_path, class: "text-gray-600 hover:text-gray-900 px-4 py-1" %></li>
+            <li><a href="https://roadmap.civicpatch.org/" class="text-gray-600 hover:text-gray-900 px-4 py-1" target="_blank" rel="noopener">Roadmap</a></li>
           </ul>
         </div>
       </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,8 +30,23 @@
   </head>
 
   <body class="min-h-screen bg-gray-50">
+    <header>
+      <nav class="flex justify-between items-center bg-white border-b border-gray-200 px-4 py-3">
+        <div class="nav-links left-0 md:w-auto w-full flex items-center">
+          <%= link_to root_path, class: "text-lg font-semibold text-gray-900" do %>
+            CivicPatch
+          <% end %>
+        </div>
+        <div class="flex md:flex-row flex-col md:items-center p-3">
+          <ul class="flex space-x-8">
+            <li><%= link_to "Home", root_path, class: "text-gray-600 hover:text-gray-90 px-4 py-1" %></li>
+            <li><%= link_to "Progress", progress_path, class: "text-gray-600 hover:text-gray-900 px-4 py-1" %></li>
+          </ul>
+        </div>
+      </nav>
+    </header>
     <main class="min-h-[600px] container mx-auto mt-28 px-5 flex">
       <%= yield %>
     </main>
   </body>
-</html>
+</html> 


### PR DESCRIPTION
Ref: 
- [FRONTEND] Link/display progress map
- Link to roadmap from civicpatch.org

This work adds: 
- responsive navigation to the progress page and roadmap
- a text based logo on all current/future pages

<img width="542" height="361" alt="Screenshot 2025-10-07 at 14 50 31" src="https://github.com/user-attachments/assets/20cf2d93-1e4f-4a56-bd42-a817293cc73a" />

